### PR TITLE
[#61] Update jtskit --> jsontableschema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ shippable/*
 /docs/_build
 /docs/_static
 /docs/_templates
+.cache/

--- a/goodtables/processors/schema.py
+++ b/goodtables/processors/schema.py
@@ -4,7 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import jtskit
+import jsontableschema
 from . import base
 
 
@@ -86,8 +86,8 @@ class SchemaProcessor(base.Processor):
 
     def schema_model(self, schema):
         try:
-            model = jtskit.models.SchemaModel(schema, self.case_insensitive_headers)
-        except (jtskit.exceptions.InvalidJSONError, jtskit.exceptions.InvalidSchemaError) as e:
+            model = jsontableschema.model.SchemaModel(schema, self.case_insensitive_headers)
+        except (jsontableschema.exceptions.InvalidJSONError, jsontableschema.exceptions.InvalidSchemaError) as e:
             raise e
 
         return model
@@ -96,7 +96,7 @@ class SchemaProcessor(base.Processor):
 
         if (self.schema is None) and self.infer_schema:
             sample_values = data_table.get_sample(300)
-            self.schema = self.schema_model(jtskit.infer(data_table.headers, sample_values))
+            self.schema = self.schema_model(jsontableschema.infer(data_table.headers, sample_values))
 
         return True, data_table
 
@@ -189,7 +189,14 @@ class SchemaProcessor(base.Processor):
                     # we know the field is in the schema
                     else:
                         # check type and format
-                        if self.schema.cast(column_name, column_value) is False:
+                        try:
+                            schema_cast = self.schema.cast(column_name,
+                                                           column_value)
+                        except (jsontableschema.exceptions.InvalidCastError,
+                                jsontableschema.exceptions.ConstraintError):
+                            schema_cast = False
+
+                        if schema_cast is False:
 
                             valid = False
                             _type = RESULTS['schema_003']

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,5 +4,5 @@ jsonschema==2.4.0
 chardet==2.3.0
 xlrd>=0.9.3
 tellme>=0.2.4
-jtskit>=0.2.7
+jsontableschema>=0.5.1
 beautifulsoup4>=4.3.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ dependencies = [
     'chardet>=2.3.0',
     'xlrd>=0.9.3',
     'tellme>=0.2.4',
-    'jtskit>=0.2.7',
+    'jsontableschema>=0.5.1',
     'beautifulsoup4>=4.3.2'
 ]
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,7 +11,7 @@ from goodtables import processors
 from goodtables import exceptions
 from goodtables.pipeline import Pipeline
 from goodtables.utilities import table_schema
-from jtskit.exceptions import InvalidJSONError, InvalidSchemaError
+from jsontableschema.exceptions import InvalidJSONError, InvalidSchemaError
 from tests import base
 
 
@@ -498,7 +498,7 @@ class TestSchemaProcessor(base.BaseTestCase):
                           schema=schema)
 
     def test_standalone_invalid_schema_jts_raises(self):
-        schema = 'https://raw.githubusercontent.com/okfn/jtskit-py/master/examples/schema_invalid_empty.json'
+        schema = 'https://raw.githubusercontent.com/okfn/jsontableschema-py/master/examples/schema_invalid_empty.json'
 
         self.assertRaises(InvalidSchemaError, processors.SchemaProcessor,
                           schema=schema)
@@ -513,7 +513,7 @@ class TestSchemaProcessor(base.BaseTestCase):
 
     def test_pipeline_invalid_schema_jts_raises(self):
         filepath = os.path.join(self.data_dir, 'case_insensitive_headers.csv')
-        schema = 'https://raw.githubusercontent.com/okfn/jtskit-py/master/examples/schema_invalid_empty.json'
+        schema = 'https://raw.githubusercontent.com/okfn/jsontableschema-py/master/examples/schema_invalid_empty.json'
         options = {'schema': {'schema': schema}}
 
         self.assertRaises(InvalidSchemaError, Pipeline, filepath,


### PR DESCRIPTION
jsontableschema 0.5.1 has been released and supersedes jtskit.

This commit changes jtskit imports to jsontableschema. A small functionality change is that `jsontableschema.model.SchemaModel.cast()` no longer returns `False` for invalid values, but instead raises jsontableschema exceptions. These are caught in GoodTables and the variable assigned False, so the code can carry on as before.